### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Prerequisites:
 
 Then:
 
-1. Download the `.zip` file from the latest [release](releases/latest) and extract it to:
+1. Download the `.zip` file from the latest[release](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugin.Install/releases) and extract it to:
    - `%LocalAppData%\Microsoft\PowerToys\PowerToys Run\Plugins`
 2. Restart PowerToys
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Prerequisites:
 
 Then:
 
-1. Download the `.zip` file from the latest[release](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugin.Install/releases) and extract it to:
+1. Download the `.zip` file from the latest [release](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugin.Install/releases/latest) and extract it to:
    - `%LocalAppData%\Microsoft\PowerToys\PowerToys Run\Plugins`
 2. Restart PowerToys
 


### PR DESCRIPTION
the readme md used to have a "release" link that was just "releases/latest". relative links in gh markdown dont work for release pages, so i replaced it with an absolute link